### PR TITLE
Wrap collections

### DIFF
--- a/src/contextual/http.clj
+++ b/src/contextual/http.clj
@@ -98,20 +98,17 @@
                  (path->ir url url-sep)
                path (as-> $ `(~'str ~$ "/" ~(path->ir path)))
                serialize-query-params (as-> $ `(~'str ~$ "?" ~(qs->ir query-params))))]
-     `(~'-map
-       ~(cond->
-           {:method method
-            :url url}
-         headers (assoc :headers `(~'-map ~headers))
-         (and query-params (not serialize-query-params)) (assoc :query-params `(~'-map ~query-params))
-         body (assoc :body (let [body `(~'-map ~body)]
-                             (if serialize-body
-                               (list 'body-serializer body)
-                               body)))
-         form (assoc :form (let [form `(~'-map ~form)]
-                             (if serialize-form
-                               (list 'form-serializer form)
-                               form))))))))
+     (cond->
+         {:method method
+          :url url}
+       headers (assoc :headers headers)
+       (and query-params (not serialize-query-params)) (assoc :query-params query-params)
+       body (assoc :body (if serialize-body
+                           (list 'body-serializer body)
+                           body))
+       form (assoc :form (if serialize-form
+                           (list 'form-serializer form)
+                           form))))))
 
 (comment
   (p/-invoke

--- a/src/contextual/impl/box.clj
+++ b/src/contextual/impl/box.clj
@@ -29,6 +29,8 @@
   (pr-str
    (->box 1)))
 
+(defn box? [x] (instance? Box x))
+
 (defn unbox
   [x]
   (if (p/-boxed? x)

--- a/src/contextual/impl/collections.clj
+++ b/src/contextual/impl/collections.clj
@@ -56,6 +56,9 @@
 (defrecord VectorWrapper [v]
   p/IContext
   (-invoke [this ctx]
-    (into [] (map p/-invoke) v)))
+    (into [] (map p/-invoke) v))
+  p/IBox
+  (-boxed? [this] true)
+  (-get [this] v))
 
 (defn ->vector [v] (->VectorWrapper v))

--- a/src/contextual/impl/compile.clj
+++ b/src/contextual/impl/compile.clj
@@ -7,6 +7,7 @@
    [contextual.impl.string :as s :refer [->str ->join]]
    [contextual.impl.invoke :as i]
    [contextual.impl.box :as b]
+   [contextual.impl.collections :as c]
    [contextual.impl.protocols :as p]))
 
 (def symbols-registry
@@ -61,11 +62,14 @@
               (apply f' args)
               (apply i/->fn f args)))
           (symbol? expr) (expand-symbol registry lookup expr)
+          (instance? clojure.lang.MapEntry expr) expr
+          (map? expr) (c/->map expr)
+          (vector? expr) (c/->vector expr)
           (or
-           (number? expr)
-           (char? expr)
            (string? expr)
            (keyword? expr)
+           (number? expr)
+           (char? expr)
            (nil? expr)
            ) (b/->box expr)
           :else expr))

--- a/src/contextual/impl/let.clj
+++ b/src/contextual/impl/let.clj
@@ -2,6 +2,7 @@
   (:require
    [contextual.walk :as walk]
    [contextual.impl.protocols :as p]
+   [contextual.impl.box :as b]
    [contextual.impl.environment :as e]))
 
 (defn- symbol-lookup
@@ -211,9 +212,15 @@
 
 (def-bindings)
 
+(defn- unparse-bindings
+  [args]
+  (let [v (b/unbox args)]
+    (into [] (comp (partition-all 2) (map (fn [[k v]] [(b/unbox k) v])) cat) v)))
+
 (defn ->bindings
   [args]
-  (let [n (/ (count args) 2)
+  (let [args (unparse-bindings args)
+        n (/ (count args) 2)
         c (get @binding-builders n)]
     (if c
       (apply c args)

--- a/test/contextual/http_test.clj
+++ b/test/contextual/http_test.clj
@@ -9,46 +9,46 @@
   (t/testing "URL compiler"
     (t/testing "Simple"
       (t/is
-       (= '(-map {:url "https://foo.bar.com"
-                  :method "GET"})
+       (= {:url "https://foo.bar.com"
+           :method "GET"}
           (sut/request '{:url "https://foo.bar.com"}
                        {}))))
 
     (t/testing "Expression"
       (t/is
-       (= '(-map {:url (str "https://" (path :foo) ".bar.com")
-                  :method "GET"})
+       (= '{:url (str "https://" (path :foo) ".bar.com")
+            :method "GET"}
           (sut/request '{:url (str "https://" (path :foo) ".bar.com")}
                        {}))))
 
     (t/testing "Vector"
       (t/is
-       (= '(-map {:url (str "https://hello." (path :foo) ".bar.com")
-                  :method "GET"})
+       (= '{:url (str "https://hello." (path :foo) ".bar.com")
+            :method "GET"}
           (sut/request '{:url ["https://hello" (path :foo) "bar.com"]}
                        {})))))
 
   (t/testing "Path compiler"
     (t/testing "Simple"
       (t/is
-       (= '(-map {:url (str "https://foo.bar.com" "/" "fizz/buzz")
-                  :method "GET"})
+       (= '{:url (str "https://foo.bar.com" "/" "fizz/buzz")
+            :method "GET"}
           (sut/request '{:url "https://foo.bar.com"
                          :path "fizz/buzz"}
                        {}))))
 
     (t/testing "Expression"
       (t/is
-       (= '(-map {:url (str (str "https://" (path :foo) ".bar.com") "/" (path :bar))
-                  :method "GET"})
+       (= '{:url (str (str "https://" (path :foo) ".bar.com") "/" (path :bar))
+            :method "GET"}
           (sut/request '{:url (str "https://" (path :foo) ".bar.com")
                          :path [(path :bar)]}
                        {}))))
 
     (t/testing "Vector"
       (t/is
-       (= '(-map {:url (str (str "https://hello." (path :foo) ".bar.com") "/" (str "fizz/" (path :buzz)))
-                  :method "GET"})
+       (= '{:url (str (str "https://hello." (path :foo) ".bar.com") "/" (str "fizz/" (path :buzz)))
+            :method "GET"}
           (sut/request '{:url ["https://hello" (path :foo) "bar.com"]
                          :path ["fizz" (path :buzz)]}
                        {})))))
@@ -57,16 +57,16 @@
   (t/testing "Query params"
     (t/testing "As map"
       (t/is
-       (= '(-map {:url (str "https://" (path :foo) ".bar.com")
-                  :method "GET"
-                  :query-params (-map {:a 1})})
+       (= '{:url (str "https://" (path :foo) ".bar.com")
+            :method "GET"
+            :query-params {:a 1}}
           (sut/request '{:url (str "https://" (path :foo) ".bar.com")
                          :query-params {:a 1}}
                        {}))))
     (t/testing "Serialized"
       (t/is
-       (= '(-map {:url (str (str "https://" (path :foo) ".bar.com") "?" (str "a=1&" __qs-trim))
-                  :method "GET"})
+       (= '{:url (str (str "https://" (path :foo) ".bar.com") "?" (str "a=1&" __qs-trim))
+            :method "GET"}
           (sut/request '{:url (str "https://" (path :foo) ".bar.com")
                          :query-params {:a 1}}
                        {:serialize-query-params true})))))
@@ -75,18 +75,18 @@
 
     (t/testing "As map"
       (t/is
-       (= '(-map {:url "https://bar.com"
-                  :method "GET"
-                  :body (-map {:a 1})})
+       (= '{:url "https://bar.com"
+            :method "GET"
+            :body {:a 1}}
           (sut/request '{:url "https://bar.com"
                          :body {:a 1}}
                        {}))))
 
     (t/testing "Serialized"
       (t/is
-       (= '(-map {:url "https://bar.com"
-                  :body (body-serializer (-map {:a 1}))
-                  :method "GET"})
+       (= '{:url "https://bar.com"
+            :body (body-serializer {:a 1})
+            :method "GET"}
           (sut/request '{:url "https://bar.com"
                          :body {:a 1}}
                        {:serialize-body true})))))
@@ -94,18 +94,18 @@
   (t/testing "Form"
     (t/testing "As map"
       (t/is
-       (= '(-map {:url "https://bar.com"
-                  :method "GET"
-                  :form (-map {:a 1})})
+       (= '{:url "https://bar.com"
+            :method "GET"
+            :form {:a 1}}
           (sut/request '{:url "https://bar.com"
                          :form {:a 1}}
                        {}))))
 
     (t/testing "Serialized"
       (t/is
-       (= '(-map {:url "https://bar.com"
-                  :form (form-serializer (-map {:a 1}))
-                  :method "GET"})
+       (= '{:url "https://bar.com"
+            :form (form-serializer {:a 1})
+            :method "GET"}
           (sut/request '{:url "https://bar.com"
                          :form {:a 1}}
                        {:serialize-form true}))))))

--- a/test/contextual/impl/compile_test.clj
+++ b/test/contextual/impl/compile_test.clj
@@ -6,7 +6,8 @@
    [contextual.impl.path :refer [->path]]
    [contextual.impl.invoke :refer [->fn]]
    [contextual.impl.protocols :as p]
-   [clojure.test :as t]))
+   [clojure.test :as t]
+   [contextual.impl.collections :as c]))
 
 (defonce lookup (into {} (map (fn [[k v]] [k (deref v)])) (ns-publics 'clojure.core)))
 
@@ -33,9 +34,9 @@
 
 (t/deftest lookup-table
   (t/testing "Lookup table resolves to bound symbol"
-    (t/is (= [1] (sut/-compile '[a] {'a 1}))))
+    (t/is (= (c/->vector [1]) (sut/-compile '[a] {'a 1}))))
   (t/testing "Unresolved symbol is expanded to run-time resolve"
-    (t/is (= [(l/->lookup 'a)] (sut/-compile '[a])))))
+    (t/is (= (c/->vector [(l/->lookup 'a)]) (sut/-compile '[a])))))
 
 (t/deftest invoke
   (t/testing "Function invoke"


### PR DESCRIPTION
Always wrap collections with `contextual.impl.collections` boxes.
Promote constant collections (every member is a box) into a box containing unboxed values.
Closes #5 