### PR TITLE
Remove builders

### DIFF
--- a/src/contextual/impl/string.clj
+++ b/src/contextual/impl/string.clj
@@ -24,44 +24,43 @@
   [delim args]
   (->Str (interpose delim args)))
 
-(defonce ^:private str-builders (atom {}))
-
 (defmacro ^:private def-str []
   (let [ctx 'ctx
         name "Str"
         sb (with-meta 'sb {:tag "StringBuilder"})
         defs
-        (for [n (range 1 23)
+        (for [n (range 1 21)
               :let [args (map (comp symbol #(str "a" %)) (range n))
                     rec (symbol (str name n))
                     constructor (symbol (str "->" rec))
                     parts (map (fn [a] `(p/-invoke-with-builder ~a ~ctx ~sb)) args)]]
-          `(do
-             (defrecord ~rec [~@args]
-               p/IStringBuild
-               (-invoke-with-builder [~'this ~ctx ~'sb]
-                 ~@parts)
-               p/IContext
-               (-invoke [~'this ~ctx]
+          {:rec
+           `(defrecord ~rec [~@args]
+              p/IStringBuild
+              (-invoke-with-builder [~'this ~ctx ~'sb]
+                ~@parts)
+              p/IContext
+              (-invoke [~'this ~ctx]
                 (let [~sb (StringBuilder.)]
                   (p/-invoke-with-builder ~'this ~ctx ~sb)
                   (.toString ~sb))))
-             (swap! str-builders assoc ~n ~constructor)))]
+           :call (if (= n 20)
+                   (let [args (butlast args)
+                         argv (into [] (concat args ['& 'args]))]
+                     `([~@argv] (~constructor ~@args (apply ~'->str ~'args))))
+                   `([~@args] (~constructor ~@args)))})]
     `(do
-       ~@defs)))
+       ~@(map :rec defs)
+       (defn ~'->str ~@(map :call defs)))))
 
 (def-str)
 
-(defn ->str
-  [& args]
-  (let [n (count args)
-        c (get @str-builders n)]
-    (if c
-      (apply c args)
-      (->Str args))))
-
 (comment
-  (p/-invoke (->str 1 2 3) nil))
+  (p/-invoke (->str 1 2 3) nil)
+  (p/-invoke (apply ->str (range 19)) nil)
+  (p/-invoke (apply ->str (range 20)) nil)
+  (p/-invoke (apply ->str (range 21)) nil)
+  (p/-invoke (apply ->str (range 80)) nil))
 
 (defn ->join
   [delim & args]


### PR DESCRIPTION
Different record structures instantiation is now done via directly dispatching to the correct constructor by way of variadic arity function instead of lookup in an atom.

This change wasn't applied to collection wrappers since their correctness will be asserted at read time.